### PR TITLE
Fixes a bug when players cannot switch between 2 abilities

### DIFF
--- a/src/main/java/iskallia/vault/event/InputEvents.java
+++ b/src/main/java/iskallia/vault/event/InputEvents.java
@@ -50,7 +50,7 @@ public class InputEvents {
     private static void onInput(Minecraft minecraft, int key, int action) {
         if (minecraft.currentScreen == null && ModKeybinds.abilityWheelKey.getKey().getKeyCode() == key) {
             if (action != GLFW.GLFW_PRESS) return;
-            if (AbilitiesOverlay.learnedAbilities.size() <= 2) return;
+            if (AbilitiesOverlay.learnedAbilities.size() < 2) return;
             minecraft.displayGuiScreen(new AbilitySelectionScreen());
             ModNetwork.CHANNEL.sendToServer(new AbilityKeyMessage(true));
 


### PR DESCRIPTION
Apparently, this was a left-over from the first ability switch version.
Fixes #29