### PR TITLE
Implement an option to set different Vault Fighters (#268).

### DIFF
--- a/src/main/java/iskallia/vault/config/VaultFightersConfig.java
+++ b/src/main/java/iskallia/vault/config/VaultFightersConfig.java
@@ -1,0 +1,54 @@
+package iskallia.vault.config;
+
+import com.google.gson.annotations.Expose;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * This config allows to switch which name vault fighters will have.
+ * It operates in 4 modes:
+ * Mode.PLAYER - the player who started the vault will be a fighter.
+ * Mode.ONLINE_PLAYERS - the random player from all online players will be a fighter.
+ * Mode.WHITELIST - the random player from server whitelist will be a fighter.
+ * Mode.LIST - the random name from the given fighter list will be a fighter.
+ *
+ * FIGHTER_LIST will operate only in LIST mode.
+ */
+public class VaultFightersConfig extends Config {
+	/**
+	 * Variable that stores currently active pool mode.
+	 */
+	@Expose public Mode POOL_MODE;
+
+	/**
+	 * List of custom defined fighters which will be active if mode is set to the list.
+	 */
+	@Expose public List<String> FIGHTER_LIST;
+
+
+	/**
+	 * Different modes for the raffle fighter choosing.
+	 */
+	public enum Mode {
+		// The player who started the vault
+		PLAYER,
+		// Random player from online player list.
+		ONLINE_PLAYERS,
+		// Random player from whitelisted player list.
+		WHITELIST,
+		// Random player from given list.
+		LIST
+	}
+
+	@Override
+	public String getName() {
+		return "vault_fighters";
+	}
+
+	@Override
+	protected void reset() {
+		POOL_MODE = Mode.PLAYER;
+		FIGHTER_LIST = Collections.emptyList();
+	}
+}

--- a/src/main/java/iskallia/vault/entity/VaultFighterEntity.java
+++ b/src/main/java/iskallia/vault/entity/VaultFighterEntity.java
@@ -1,5 +1,7 @@
 package iskallia.vault.entity;
 
+import iskallia.vault.config.VaultFightersConfig;
+import iskallia.vault.init.ModConfigs;
 import iskallia.vault.world.data.VaultRaidData;
 import iskallia.vault.world.raid.VaultRaid;
 import net.minecraft.entity.EntityType;
@@ -27,9 +29,45 @@ public class VaultFighterEntity extends FighterEntity {
 		if(!this.world.isRemote) {
 			VaultRaid raid = VaultRaidData.get((ServerWorld)this.world).getAt(this.getPosition());
 
-			if(raid != null) {
-				ServerPlayerEntity player = ((ServerWorld)world).getServer().getPlayerList().getPlayerByUUID(raid.playerIds.get(0));
-				String name = player != null ? player.getName().getString() : "";
+			if (raid != null) {
+				String name;
+
+				// Resolves a risk of incorrect input value.
+				if (ModConfigs.VAULT_FIGHTERS.POOL_MODE == null) {
+					ModConfigs.VAULT_FIGHTERS.POOL_MODE = VaultFightersConfig.Mode.PLAYER;
+				}
+
+				switch (ModConfigs.VAULT_FIGHTERS.POOL_MODE) {
+					case ONLINE_PLAYERS: {
+						// Choose random name from online player list.
+						String[] onlinePlayerNames = ((ServerWorld) world).getServer().getPlayerList().getOnlinePlayerNames();
+						name = onlinePlayerNames[world.getRandom().nextInt(onlinePlayerNames.length)];
+						break;
+					}
+					case WHITELIST: {
+						// Choose random name from whitelist.
+						String[] whitelistedPlayerNames = ((ServerWorld) world).getServer().getPlayerList().getWhitelistedPlayerNames();
+						name = whitelistedPlayerNames[world.getRandom().nextInt(whitelistedPlayerNames.length)];
+						break;
+					}
+					case LIST: {
+						// Choose random name from fighter list.
+						int nextFighter = world.getRandom().nextInt(ModConfigs.VAULT_FIGHTERS.FIGHTER_LIST.size());
+						name = ModConfigs.VAULT_FIGHTERS.FIGHTER_LIST.get(nextFighter);
+						break;
+					}
+					default: {
+						// Use raid player name.
+						ServerPlayerEntity player = ((ServerWorld) world).getServer().getPlayerList().getPlayerByUUID(raid.playerIds.get(0));
+						name = player != null ? player.getName().getString() : "";
+						break;
+					}
+				}
+
+				if (name == null) {
+					name = "";
+				}
+
 				this.setCustomName(new StringTextComponent(name));
 			}
 		}

--- a/src/main/java/iskallia/vault/init/ModConfigs.java
+++ b/src/main/java/iskallia/vault/init/ModConfigs.java
@@ -56,6 +56,7 @@ public class ModConfigs {
     public static GlobalTraderConfig GLOBAL_TRADER;
     public static PlayerExpConfig PLAYER_EXP;
     public static FinalVaultGeneralConfig FINAL_VAULT_GENERAL;
+    public static VaultFightersConfig VAULT_FIGHTERS;
 
     public static void register() {
         ABILITIES = (AbilitiesConfig) new AbilitiesConfig().readConfig();
@@ -106,6 +107,7 @@ public class ModConfigs {
         GLOBAL_TRADER = (GlobalTraderConfig) new GlobalTraderConfig().readConfig();
         PLAYER_EXP = (PlayerExpConfig) new PlayerExpConfig().readConfig();
         FINAL_VAULT_GENERAL = (FinalVaultGeneralConfig) new FinalVaultGeneralConfig().readConfig();
+        VAULT_FIGHTERS = (VaultFightersConfig) new VaultFightersConfig().readConfig();
         Vault.LOGGER.info("Vault Configs are loaded successfully!");
     }
 


### PR DESCRIPTION
This code adds a new config that allows changing Vault Fighter names. It has 4 operational modes:

- Mode.PLAYER - the player who started the vault will be a fighter.
- Mode.ONLINE_PLAYERS - the random player from all online players will be a fighter.
- Mode.WHITELIST - the random player from the server whitelist will be a fighter.
- Mode.LIST - the random name from the given fighter list will be a fighter.

The Mode.LIST enables the FIGHTER_LIST option which can contain any names.

I understand that you do not accept Pull Requests and mostly working on the 2.0 version, however, I just wanted to get this working at least in my own version and share if someone wants to get it too.