### PR TITLE
Fixes bug with Star Core recipe

### DIFF
--- a/src/main/resources/data/the_vault/recipes/star_core.json
+++ b/src/main/resources/data/the_vault/recipes/star_core.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "dbd",
+    " b ",
     "bcb",
-    "dbd"
+    " b "
   ],
   "key": {
     "b": {
@@ -11,9 +11,6 @@
     },
     "c": {
       "item": "the_vault:vault_diamond_block"
-    },
-    "d": {
-      "item": "minecraft:air"
     }
   },
   "result": {


### PR DESCRIPTION
AIR by default is not an accessible item by users. If it is defined in a recipe, then GUI will not display it, as it considers it as uncraftable.

This partly fixes #258