### PR TITLE
Fixes missing Mystery Stew Recipe in JEI and Crafting Books.

### DIFF
--- a/src/main/java/iskallia/vault/init/ModRecipes.java
+++ b/src/main/java/iskallia/vault/init/ModRecipes.java
@@ -1,7 +1,6 @@
 package iskallia.vault.init;
 
 import iskallia.vault.Vault;
-import iskallia.vault.recipe.MysteryStewRecipe;
 import iskallia.vault.recipe.RelicSetRecipe;
 import iskallia.vault.recipe.UnidentifiedRelicRecipe;
 import iskallia.vault.recipe.UpgradeCrystalRecipe;
@@ -14,13 +13,12 @@ public class ModRecipes {
 
 	public static class Serializer {
 		public static SpecialRecipeSerializer<RelicSetRecipe> CRAFTING_SPECIAL_RELIC_SET;
-		public static SpecialRecipeSerializer<MysteryStewRecipe> CRAFTING_SPECIAL_MYSTERY_STEW;
+		//public static SpecialRecipeSerializer<MysteryStewRecipe> CRAFTING_SPECIAL_MYSTERY_STEW;
 		public static SpecialRecipeSerializer<UnidentifiedRelicRecipe> CRAFTING_SPECIAL_UNIDENTIFIED_RELIC;
 		public static SpecialRecipeSerializer<UpgradeCrystalRecipe> CRAFTING_SPECIAL_UPGRADE_CRYSTAL;
 
 		public static void register(RegistryEvent.Register<IRecipeSerializer<?>> event) {
 			CRAFTING_SPECIAL_RELIC_SET = register(event, "crafting_special_relic_set", new SpecialRecipeSerializer<>(RelicSetRecipe::new));
-			CRAFTING_SPECIAL_MYSTERY_STEW = register(event, "crafting_special_mystery_stew", new SpecialRecipeSerializer<>(MysteryStewRecipe::new));
 			CRAFTING_SPECIAL_UNIDENTIFIED_RELIC = register(event, "crafting_special_unidentified_relic", new SpecialRecipeSerializer<>(UnidentifiedRelicRecipe::new));
 			CRAFTING_SPECIAL_UPGRADE_CRYSTAL = register(event, "crafting_special_upgrade_crystal", new SpecialRecipeSerializer<>(UpgradeCrystalRecipe::new));
 		}

--- a/src/main/java/iskallia/vault/recipe/MysteryStewRecipe.java
+++ b/src/main/java/iskallia/vault/recipe/MysteryStewRecipe.java
@@ -63,7 +63,7 @@ public class MysteryStewRecipe extends SpecialRecipe {
 
 	@Override
 	public IRecipeSerializer<?> getSerializer() {
-		return ModRecipes.Serializer.CRAFTING_SPECIAL_MYSTERY_STEW;
+		return ModRecipes.Serializer.CRAFTING_SPECIAL_RELIC_SET;//CRAFTING_SPECIAL_MYSTERY_STEW;
 	}
 
 }

--- a/src/main/resources/data/the_vault/recipes/mystery_stew.json
+++ b/src/main/resources/data/the_vault/recipes/mystery_stew.json
@@ -1,3 +1,36 @@
 {
-  "type": "the_vault:crafting_special_mystery_stew"
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:bowl"
+    },
+    {
+      "item": "the_vault:vault_diamond"
+    },
+    {
+      "item": "the_vault:hunter_eye"
+    },
+    {
+      "item": "the_vault:oozing_pizza"
+    },
+    {
+      "item": "the_vault:poisonous_mushroom"
+    },
+    {
+      "item": "the_vault:sweet_kiwi"
+    },
+    {
+      "tag": "the_vault:gems"
+    },
+    {
+      "tag": "the_vault:gems"
+    },
+    {
+      "tag": "the_vault:gems"
+    }
+  ],
+  "result": {
+    "item": "the_vault:vault_stew_mystery",
+    "count": 1
+  }
 }

--- a/src/main/resources/data/the_vault/tags/items/gems.json
+++ b/src/main/resources/data/the_vault/tags/items/gems.json
@@ -1,0 +1,17 @@
+{
+  "replace": false,
+  "values": [
+    "the_vault:vault_rock",
+    "the_vault:gem_alexandrite",
+    "the_vault:gem_benitoite",
+    "the_vault:gem_larimar",
+    "the_vault:gem_black_opal",
+    "the_vault:gem_painite",
+    "the_vault:gem_iskallium",
+    "the_vault:gem_renium",
+    "the_vault:gem_gorginite",
+    "the_vault:gem_sparkletine",
+    "the_vault:gem_wutodie",
+    "the_vault:gem_pog"
+  ]
+}


### PR DESCRIPTION
Instead of using a custom codded recipe, use Mojang provided recipe structure with shapeless recipe and tags. 

Adds new tag `the_vault:gems` which contains:
-  "the_vault:vault_rock"
-  "the_vault:gem_alexandrite"
-  "the_vault:gem_benitoite"
-  "the_vault:gem_larimar"
-  "the_vault:gem_black_opal"
-  "the_vault:gem_painite"
-  "the_vault:gem_iskallium"
-  "the_vault:gem_renium"
-  "the_vault:gem_gorginite"
-  "the_vault:gem_sparkletine"
-  "the_vault:gem_wutodie"
-  "the_vault:gem_pog"

Adjust mystery_stew recipe so it used tag `the_vualt:gems` and proper items.

Part of #258