### PR TITLE
Fixes broken Twitch Relic Statute

### DIFF
--- a/src/main/resources/assets/the_vault/models/item/vault_relic.json
+++ b/src/main/resources/assets/the_vault/models/item/vault_relic.json
@@ -21,6 +21,12 @@
     },
     {
       "predicate": {
+        "custom_model_data": 3
+      },
+      "model": "the_vault:item/statue_twitch"
+    },
+    {
+      "predicate": {
         "custom_model_data": 4
       },
       "model": "the_vault:item/statue_cupcake"


### PR DESCRIPTION
For some reason, twitch statute model was missing in the vault_relic model.

Resolves #282