### PR TITLE
Fixes broken step-up talent.

### DIFF
--- a/src/main/java/iskallia/vault/skill/talent/type/StepTalent.java
+++ b/src/main/java/iskallia/vault/skill/talent/type/StepTalent.java
@@ -30,8 +30,8 @@ public class StepTalent extends PlayerTalent {
 	@Override
 	public void onAdded(PlayerEntity player) {
 		//System.out.println(player.stepHeisght);
-		player.stepHeight += this.stepHeightAddend;
-		set((ServerPlayerEntity)player, player.stepHeight + this.stepHeightAddend);
+		//player.stepHeight += this.stepHeightAddend;
+		set((ServerPlayerEntity) player, player.stepHeight + this.stepHeightAddend);
 		//System.out.println(player.stepHeight);
 	}
 
@@ -60,8 +60,9 @@ public class StepTalent extends PlayerTalent {
 			totalStepHeight += talent.getStepHeightAddend();
 		}
 
-		if(totalStepHeight != 0.0F) {
-			set(player, player.stepHeight + totalStepHeight);
+		// Add stepHeight from default value, what is 1.0F
+		if (totalStepHeight != 0.0F) {
+			set(player, 1.0F + totalStepHeight);
 		}
 	}
 


### PR DESCRIPTION
The were 2 issues to the step-up talent, first one was that it added 2x config value, and second one was that on world switch it kept increasing the step-up value by config value.

It is fixed by removing unnecessary sum in the StepTalent#onAdded method and by changing player.stepHeight to 1.0F (default value) in StepTalent#onEntityCreated method.

Fixes of #255