### PR TITLE
Fix a bug that allowed creating portals in any dimension.

### DIFF
--- a/src/main/java/iskallia/vault/item/ItemVaultCrystal.java
+++ b/src/main/java/iskallia/vault/item/ItemVaultCrystal.java
@@ -115,6 +115,11 @@ public class ItemVaultCrystal extends Item {
     }
 
     private boolean tryCreatePortal(ItemVaultCrystal crystal, World world, BlockPos pos, Direction facing, String playerBossName, CrystalData data) {
+        if (world.getDimensionKey() != World.OVERWORLD)
+        {
+            return false;
+        }
+
         Optional<VaultPortalSize> optional = VaultPortalSize.getPortalSize(world, pos.offset(facing), Direction.Axis.X);
         if (optional.isPresent()) {
             optional.get().placePortalBlocks(crystal, playerBossName, data);


### PR DESCRIPTION
By the code it is assumed that portals will be created only in the overworld, however, there were no additional checks on that, and players were able to create portals in any dimension, even in Vault Dimension.

This is a major bug, as players could always create an exit portal at any position in the vault.
I do not see a benefit of allowing the nether and the end dimensions, as this will be in line with nether portal behavior.

Fixes #273 and #281.