### PR TITLE
Fix bugs with item insertion via hopper.

### DIFF
--- a/src/main/java/iskallia/vault/block/entity/VaultAltarTileEntity.java
+++ b/src/main/java/iskallia/vault/block/entity/VaultAltarTileEntity.java
@@ -261,18 +261,30 @@ public class VaultAltarTileEntity extends TileEntity implements ITickableTileEnt
                 if (recipe != null && !recipe.getRequiredItems().isEmpty()) {
                     List<RequiredItem> items = recipe.getRequiredItems();
                     for (RequiredItem item : items) {
-                        if (item.reachedAmountRequired()) {
-                            return stack;
-                        }
                         if (item.isItemEqual(stack)) {
+                            if (item.reachedAmountRequired()) {
+                                return stack;
+                            }
                             int amount = stack.getCount();
                             int excess = item.getRemainder(amount);
                             if (excess > 0) {
-                                item.setCurrentAmount(item.getAmountRequired());
+                                // VanillaInventoryCodeHooks#insertItem operates in 2 modes: simulate and actual insert.
+                                // It triggers it 2 times, first time to check if it works, and second time to actually
+                                // insert items. It must be required to check if simulate is false, otherwise,
+                                // all items will be inserted twice.
+                                if (!simulate) {
+                                    item.setCurrentAmount(item.getAmountRequired());
+                                }
                                 stack.setCount(excess);
                                 return ItemHandlerHelper.copyStackWithSize(stack, excess);
                             } else {
-                                item.addAmount(stack.getCount());
+                                // VanillaInventoryCodeHooks#insertItem operates in 2 modes: simulate and actual insert.
+                                // It triggers it 2 times, first time to check if it works, and second time to actually
+                                // insert items. It must be required to check if simulate is false, otherwise,
+                                // all items will be inserted twice.
+                                if (!simulate) {
+                                    item.addAmount(stack.getCount());
+                                }
                                 return ItemStack.EMPTY;
                             }
                         }


### PR DESCRIPTION
There were 2 issues:
1) items inserted via hopper were counted twice. It was because of reducing count in 'simulate' mode. If VanillaInventoryCodeHooks#insertItem is in simulate mode, it does not insert items, but just checks if the insert is possible.
2) fixes a bug when finishing one item may actually block others from inserting. Well, that should be obvious, check for completion on the correct item.

Fixes #305